### PR TITLE
Fixed some issues with logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "name": "Pier Fumagalli",
     "email": "pier@usrz.com"
   },
+  "contributors": [{
+    "name": "Lucas G. Sánchez",
+    "email": "unkiwii@gmail.com"
+  }],
   "dependencies": {
     "colors": ">=1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-verbose-reporter",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Karma reporter bringing verbosity to the max.",
   "main": "reporter.js",
   "repository": {

--- a/reporter.js
+++ b/reporter.js
@@ -136,7 +136,9 @@ function VerboseReporter(logger) {
   };
 
   this.onBrowserLog = function(browser, message, level) {
-    forBrowser(browser).log.push({level: level == 'log' ? 'info' : level, message: message});
+    if (level == 'log') level = 'info';
+    var log = logger.create(browser.name);
+    (log[level] || log.info).call(log, message);
   };
 
   this.onBrowserError = function(browser, error) {
@@ -160,11 +162,6 @@ function VerboseReporter(logger) {
     suite = suite.length > 2 ? ' | ' + suite.substring(2) + ' | ' : ' | ';
 
     var log = logger.create(browser.name + suite + result.description);
-
-    b.log.forEach(function(entry) {
-      (log[entry.level] || log.info).call(log, entry.message);
-    });
-    b.log = [];
 
     if (! tests.results) tests.results = {};
     if (! tests.results[result.description]) {

--- a/reporter.js
+++ b/reporter.js
@@ -104,7 +104,7 @@ function VerboseReporter(logger) {
       var browser = _browsers[i];
       var log = logger.create(browser.name);
       browser.log.forEach(function(entry) {
-        log[entry.level](entry.message);
+        (log[entry.level] || log.info).call(call, entry.message);
       });
       browser.log = [];
     }
@@ -136,7 +136,7 @@ function VerboseReporter(logger) {
   };
 
   this.onBrowserLog = function(browser, message, level) {
-    forBrowser(browser).log.push({level: level, message: message});
+    forBrowser(browser).log.push({level: level == 'log' ? 'info' : level, message: message});
   };
 
   this.onBrowserError = function(browser, error) {


### PR DESCRIPTION
When the application use console.log in the reporter something like this is printed:

`21 12 2016 12:46:08.109:INFO [Chrome 54.0.2840 (Linux 0.0.0) | test | case]: `

The log entry is generated and printed, but the message is invisible, even if karma log level is set to DEBUG, so I changed the reporter to use INFO instead of LOG as the level for those cases.

Also keep compatible the calls to the logger as in:

`(log[entry.level] || log.info).call(log, entry.message)`

as in [cb5b431](https://github.com/usrz/javascript-karma-verbose-reporter/commit/cb5b4315cc996b6eeaca81afa596dbdf98eb2c9d)